### PR TITLE
Create skill object and skill property

### DIFF
--- a/src/Arcane.Pathfinder.Objects/Abstractions/Character.cs
+++ b/src/Arcane.Pathfinder.Objects/Abstractions/Character.cs
@@ -1,4 +1,5 @@
-﻿using Arcane.Pathfinder.Objects.Utils;
+﻿using Arcane.Pathfinder.Objects.Models;
+using Arcane.Pathfinder.Objects.Utils;
 
 namespace Arcane.Pathfinder.Objects.Abstractions
 {
@@ -19,5 +20,7 @@ namespace Arcane.Pathfinder.Objects.Abstractions
         public int HitDice { get; private set; }
         public int HeroPoints { get; set; }
         public Alignments Alignment { get; private set; }
+
+        public Dictionary<string, Skill> CharacterSkills = new();
     }
 }

--- a/src/Arcane.Pathfinder.Objects/Abstractions/Character.cs
+++ b/src/Arcane.Pathfinder.Objects/Abstractions/Character.cs
@@ -21,6 +21,6 @@ namespace Arcane.Pathfinder.Objects.Abstractions
         public int HeroPoints { get; set; }
         public Alignments Alignment { get; private set; }
 
-        public Dictionary<string, Skill> CharacterSkills = new();
+        public List<Skill> CharacterSkills = new();
     }
 }

--- a/src/Arcane.Pathfinder.Objects/Abstractions/Character.cs
+++ b/src/Arcane.Pathfinder.Objects/Abstractions/Character.cs
@@ -4,6 +4,7 @@ namespace Arcane.Pathfinder.Objects.Abstractions
 {
     public abstract class Character
     {
+        // Hola
         private readonly int Strength;
         private readonly int Dexterity;
 

--- a/src/Arcane.Pathfinder.Objects/Abstractions/Character.cs
+++ b/src/Arcane.Pathfinder.Objects/Abstractions/Character.cs
@@ -4,12 +4,12 @@ namespace Arcane.Pathfinder.Objects.Abstractions
 {
     public abstract class Character
     {
-        private int Strength= 10;
-        private int Dexterity= 10;
-        private int Constitution= 10;
-        private int Intelligence= 10;
-        private int Wisdom= 10;
-        private int Charisma= 10;
+        private int Strength = 10;
+        private int Dexterity = 10;
+        private int Constitution = 10;
+        private int Intelligence = 10;
+        private int Wisdom = 10;
+        private int Charisma = 10;
 
         public string CharacterName { get; set; } = "Nameless";
         public string PlayerName { get; set; } = "Player";
@@ -19,6 +19,5 @@ namespace Arcane.Pathfinder.Objects.Abstractions
         public int HitDice { get; private set; }
         public int HeroPoints { get; set; }
         public Alignments Alignment { get; private set; }
-        public SkillCommon SkillCommon { get; set; }
     }
 }

--- a/src/Arcane.Pathfinder.Objects/Abstractions/ISkill.cs
+++ b/src/Arcane.Pathfinder.Objects/Abstractions/ISkill.cs
@@ -1,0 +1,7 @@
+﻿namespace Arcane.Pathfinder.Objects.Abstractions
+{
+    public interface ISkill
+    {
+        //public AtributeModifier SkillModifier { get; private set; }
+    }
+}

--- a/src/Arcane.Pathfinder.Objects/Abstractions/ISkill.cs
+++ b/src/Arcane.Pathfinder.Objects/Abstractions/ISkill.cs
@@ -2,6 +2,7 @@
 {
     public interface ISkill
     {
+        public string SkillName { get; set; }
         //public AtributeModifier SkillModifier { get; private set; }
     }
 }

--- a/src/Arcane.Pathfinder.Objects/BaseAttackTables/BaseAttackTable.cs
+++ b/src/Arcane.Pathfinder.Objects/BaseAttackTables/BaseAttackTable.cs
@@ -6,7 +6,5 @@ namespace Arcane.Pathfinder.Objects.BaseAttackTables
     {
         public int CharacterLevel { get; set; }
         public BaseAttackType BaseAttackType { get; set; }
-
-
     }
 }

--- a/src/Arcane.Pathfinder.Objects/BaseAttackTables/BaseAttackType.cs
+++ b/src/Arcane.Pathfinder.Objects/BaseAttackTables/BaseAttackType.cs
@@ -7,6 +7,5 @@ namespace Arcane.Pathfinder.Objects.BaseAttackTables
         High,
         Medium,
         Low,
-
     }
 }

--- a/src/Arcane.Pathfinder.Objects/Models/Skill.cs
+++ b/src/Arcane.Pathfinder.Objects/Models/Skill.cs
@@ -1,0 +1,11 @@
+﻿namespace Arcane.Pathfinder.Objects.Models
+{
+    public class Skill
+    {
+        public string SkillName { get; set; } = string.Empty;
+        public bool IsClassSkill { get; set; }
+        public int Ranks { get; set; }
+        public bool HasArmorPenalty { get; set; }
+        // typemod
+    }
+}

--- a/src/Arcane.Pathfinder.Objects/Models/Skill.cs
+++ b/src/Arcane.Pathfinder.Objects/Models/Skill.cs
@@ -9,6 +9,7 @@ namespace Arcane.Pathfinder.Objects.Models
         public bool IsClassSkill { get; set; }
         public int Ranks { get; set; }
         public bool HasArmorPenalty { get; set; }
+        public bool RequieredTraining { get; set; }
 
         public Skill(SkillCommon skill)
         {

--- a/src/Arcane.Pathfinder.Objects/Models/Skill.cs
+++ b/src/Arcane.Pathfinder.Objects/Models/Skill.cs
@@ -1,4 +1,5 @@
 ﻿using Arcane.Pathfinder.Objects.Abstractions;
+using Arcane.Pathfinder.Objects.Utils;
 
 namespace Arcane.Pathfinder.Objects.Models
 {
@@ -9,9 +10,9 @@ namespace Arcane.Pathfinder.Objects.Models
         public int Ranks { get; set; }
         public bool HasArmorPenalty { get; set; }
 
-        public Skill()
+        public Skill(SkillCommon skill)
         {
-
+            SkillName = nameof(skill);
         }
     }
 }

--- a/src/Arcane.Pathfinder.Objects/Models/Skill.cs
+++ b/src/Arcane.Pathfinder.Objects/Models/Skill.cs
@@ -1,11 +1,17 @@
-﻿namespace Arcane.Pathfinder.Objects.Models
+﻿using Arcane.Pathfinder.Objects.Abstractions;
+
+namespace Arcane.Pathfinder.Objects.Models
 {
-    public class Skill
+    public class Skill : ISkill
     {
         public string SkillName { get; set; } = string.Empty;
         public bool IsClassSkill { get; set; }
         public int Ranks { get; set; }
         public bool HasArmorPenalty { get; set; }
-        // typemod
+
+        public Skill()
+        {
+
+        }
     }
 }


### PR DESCRIPTION
## Cambios
- Borrado de espacios en algunas clases.
- Reemplace la propiedad `SkillCommon` por una lista de objetos de tipo `Skill`, agregada también en este PR.
- `SkillCommon` se usa ahora en el contructor de `Skill`.
- Adicionalmente se agregó una interfaz para `Skill` pero no esta completa aun ya que necesita de cosas que deben aparecer en otras tareas.